### PR TITLE
Add pin 1 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ you could get the state of the pin, it could change states, and then you could
 start waiting on it for interrupts. If that happened, you would be out of sync.
 
 
-To conect or disconnect an internal pull-up or pull-down resistor to a GPIO pin,
+To connect or disconnect an internal pull-up or pull-down resistor to a GPIO pin,
 call the `set_pull_mode` function.
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Elixir library. Normally, you would include gpio as a dependency in your
 
 ```elixir
 def deps do
-  [{:elixir_ciruits_gpio, "~> 0.1"}]
+  [{:elixir_circuits_gpio, "~> 0.1"}]
 end
 ```
 
@@ -120,6 +120,32 @@ message with the state of the pin. This prevents the race condition between
 getting the initial state of the pin and turning on interrupts. Without it,
 you could get the state of the pin, it could change states, and then you could
 start waiting on it for interrupts. If that happened, you would be out of sync.
+
+
+To conect or disconnect an internal pull-up or pull-down resistor to a GPIO pin,
+call the `set_pull_mode` function.
+
+```elixir
+iex> ElixirCircuits.GPIO.set_pull_mode(gpio, pull_mode)
+:ok
+```
+
+Valid `pull_mode` values are `:none` `:pullup`, or `:pulldown`
+
+
+Note that `set_pull_mode` is platform dependent, and currently only works for Raspberry Pi hardware.
+Calls to `set_pull_mode` on other platforms will have no effect.
+The internal pull-up resistor value is between 50K and 65K, and the pull-down is between 50K and 60K.
+It is not possible to read back the current Pull-up/down settings, 
+and GPIO pull-up pull-down resistor connections are maintained, even when the CPU is powered down.
+
+
+To get the GPIO pin number for a gpio reference, call the `pin` function. 
+
+```elixir
+iex> ElixirCircuits.GPIO.pin(gpio)
+17
+```
 
 ## FAQ
 

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -77,4 +77,12 @@ defmodule ElixirCircuits.GPIO do
   def set_pull_mode(gpio, pull_mode) do
     Nif.set_pull_mode(gpio, pull_mode)
   end
+
+  @doc """
+  Get the GPIO pin number
+  """
+  @spec pin(reference) :: pin_number | {:error, atom}
+  def pin(gpio) do
+    Nif.pin(gpio)
+  end
 end

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -32,4 +32,8 @@ defmodule ElixirCircuits.GPIO.Nif do
   def set_pull_mode(_gpio, _pull_mode) do
     :erlang.nif_error(:nif_not_loaded)
   end
+
+  def pin(_gpio) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
 end

--- a/src/gpio_nif.c
+++ b/src/gpio_nif.c
@@ -584,6 +584,15 @@ static ERL_NIF_TERM set_pull_mode(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
     return priv->atom_ok;
 }
 
+static ERL_NIF_TERM pin_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct gpio_priv *priv = enif_priv_data(env);
+    struct gpio_pin *pin;
+    if (!enif_get_resource(env, argv[0], priv->gpio_pin_rt, (void**) &pin))
+        return enif_make_badarg(env);
+
+    return enif_make_int(env, pin->pin_number);
+}
 
 static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -634,7 +643,8 @@ static ErlNifFunc nif_funcs[] = {
     {"write", 2, write_gpio, 0},
     {"set_edge_mode", 4, set_edge_mode, 0},
     {"set_direction", 2, set_direction, 0},
-    {"set_pull_mode", 2, set_pull_mode, 0}
+    {"set_pull_mode", 2, set_pull_mode, 0},
+    {"pin", 1, pin_gpio, 0}
 };
 
 ERL_NIF_INIT(Elixir.ElixirCircuits.GPIO.Nif, nif_funcs, load, NULL, NULL, unload)


### PR DESCRIPTION
Add pin/1 function to retrieve GPIO pin number for a reference.
Update README to document pin and set_pull_mode functions