### PR TITLE
Rename package to circuits_gpio/Circuits.GPIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-elixir_circuits_gpio-*.tar
+circuits_gpio-*.tar
 
 # Ignore C object files and executables
 /priv

--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
-# ElixirCircuits.GPIO
+# Elixir Circuits - GPIO
 
-[![CircleCI](https://circleci.com/gh/elixir-circuits/gpio.svg?style=svg)](https://circleci.com/gh/elixir-circuits/gpio)
-[![Hex version](https://img.shields.io/hexpm/v/gpio.svg "Hex version")](https://hex.pm/packages/gpio)
+[![CircleCI](https://circleci.com/gh/elixir-circuits/circuits_gpio.svg?style=svg)](https://circleci.com/gh/elixir-circuits/circuits_gpio)
+[![Hex version](https://img.shields.io/hexpm/v/circuits_gpio.svg "Hex version")](https://hex.pm/packages/circuits_gpio)
 
-`ElixirCircuits.GPIO` provides high level an abstraction for interfacing to GPIOs
-on Linux platforms. Internally, it uses the Linux sysclass interface
-so that it does not require platform-dependent code.
+`Circuits.GPIO` provides high level an abstraction for interfacing to GPIOs on
+Linux platforms. Internally, it uses the Linux sysclass interface so that it
+most functionality does not require platform-dependent code.
 
-`ElixirCircuits.GPIO` works great with LEDs, buttons, many kinds of sensors, and simple
-control of motors. In general, if a device requires high speed transactions or
-has hard real-time constraints in its interactions, this is not the right
-library. For those devices, it is recommended to look at other driver options, such
-as using a Linux kernel driver.
+`Circuits.GPIO` works great with LEDs, buttons, many kinds of sensors, and
+simple control of motors. In general, if a device requires high speed
+transactions or has hard real-time constraints in its interactions, this is not
+the right library. For those devices, it is recommended to look at other driver
+options, such as using a Linux kernel driver.
 
-# Getting started
+## Getting started
 
-If you're natively compiling gpio, everything should work like any other
-Elixir library. Normally, you would include gpio as a dependency in your
-`mix.exs` like this:
+If you're natively compiling `circuits_gpio`, everything should work like any
+other Elixir library. Normally, you would include `circuits_gpio` as a
+dependency in your `mix.exs` like this:
 
 ```elixir
 def deps do
-  [{:elixir_circuits_gpio, "~> 0.1"}]
+  [{:circuits_gpio, "~> 0.1"}]
 end
 ```
 
 If you just want to try it out, you can do the following:
 
 ```shell
-git clone https://github.com/elixir-circuits/gpio
-cd gpio
+git clone https://github.com/elixir-circuits/circuits_gpio
+cd circuits_gpio
 mix compile
 iex -S mix
 ```
@@ -39,74 +39,75 @@ right C compiler is called. See the `Makefile` for the variables that will need
 to be overridden. At a minimum, you will need to set `CROSSCOMPILE`,
 `ERL_CFLAGS`, and `ERL_EI_LIBDIR`.
 
-If you're trying to compile on a Raspberry Pi and you get errors indicated that Erlang headers are missing
-(`ie.h`), you may need to install erlang with `apt-get install
-erlang-dev` or build Erlang from source per instructions [here](http://elinux.org/Erlang).
+If you're trying to compile on a Raspberry Pi and you get errors indicated that
+Erlang headers are missing (`ie.h`), you may need to install erlang with
+`apt-get install erlang-dev` or build Erlang from source per instructions
+[here](http://elinux.org/Erlang).
 
-# Examples
+## Examples
 
-`ElixirCircuits.GPIO` only supports simple uses of the GPIO interface in Linux, but you can
-still do quite a bit. The following examples were tested on a
-Raspberry Pi that was connected to an [Erlang Embedded Demo
+`Circuits.GPIO` only supports simple uses of the GPIO interface in Linux, but
+you can still do quite a bit. The following examples were tested on a Raspberry
+Pi that was connected to an [Erlang Embedded Demo
 Board](http://solderpad.com/omerk/erlhwdemo/). There's nothing special about
 either the demo board or the Raspberry Pi, so these should work similarly on
 other embedded Linux platforms.
 
 ## GPIO
 
-A [General Purpose Input/Output](https://en.wikipedia.org/wiki/General-purpose_input/output) (GPIO)
-is just a wire that you can use as an input or an output. It can only be
-one of two values, 0 or 1. A 1 corresponds to a logic high voltage like 3.3 V
-and a 0 corresponds to 0 V. The actual voltage depends on the hardware.
+A [General Purpose
+Input/Output](https://en.wikipedia.org/wiki/General-purpose_input/output) (GPIO)
+is just a wire that you can use as an input or an output. It can only be one of
+two values, 0 or 1. A 1 corresponds to a logic high voltage like 3.3 V and a 0
+corresponds to 0 V. The actual voltage depends on the hardware.
 
 Here's an example of turning an LED on or off:
 
 ![GPIO LED schematic](assets/images/schematic-gpio-led.png)
 
-To turn on the LED that's connected to the net (or wire) labeled
-`GPIO18`, run the following:
+To turn on the LED that's connected to the net (or wire) labeled `GPIO18`, run
+the following:
 
 ```elixir
-iex> {:ok, gpio} = ElixirCircuits.GPIO.open(18, :output)
+iex> {:ok, gpio} = Circuits.GPIO.open(18, :output)
 {:ok, #Reference<...>}
 
-iex> ElixirCircuits.GPIO.write(gpio, 1)
+iex> Circuits.GPIO.write(gpio, 1)
 :ok
 ```
 
-Input works similarly. Here's an example of a button with a pull down
-resistor connected.
+Input works similarly. Here's an example of a button with a pull down resistor
+connected.
 
 ![GPIO Button schematic](assets/images/schematic-gpio-button.png)
 
-If you're not familiar with pull up or pull down
-resistors, they're resistors whose purpose is to drive a wire
-high or low when the button isn't pressed. In this case, it drives the
-wire low. Many processors have ways of configuring internal resistors
-to accomplish the same effect without needing to add an external resistor.
-It's platform-dependent and not shown here.
+If you're not familiar with pull up or pull down resistors, they're resistors
+whose purpose is to drive a wire high or low when the button isn't pressed. In
+this case, it drives the wire low. Many processors have ways of configuring
+internal resistors to accomplish the same effect without needing to add an
+external resistor.  It's platform-dependent and not shown here.
 
-The code looks like this in `ElixirCircuits.GPIO`:
+The code looks like this in `Circuits.GPIO`:
 
 ```elixir
-iex> {:ok, gpio} = ElixirCircuits.GPIO.open(17, :input)
+iex> {:ok, gpio} = Circuits.GPIO.open(17, :input)
 {:ok, #Reference<...>}
 
-iex> ElixirCircuits.GPIO.read(gpio)
+iex> Circuits.GPIO.read(gpio)
 0
 
 # Push the button down
 
-iex> ElixirCircuits.GPIO.read(gpio)
+iex> Circuits.GPIO.read(gpio)
 1
 ```
 
 If you'd like to get a message when the button is pressed or released, call the
-`set_edge_mode` function. You can trigger on the `:rising` edge, `:falling` edge or
-`:both`.
+`set_edge_mode` function. You can trigger on the `:rising` edge, `:falling` edge
+or `:both`.
 
 ```elixir
-iex> ElixirCircuits.GPIO.set_edge_mode(gpio, :both)
+iex> Circuits.GPIO.set_edge_mode(gpio, :both)
 :ok
 
 iex> flush
@@ -115,35 +116,34 @@ iex> flush
 :ok
 ```
 
-Note that after calling `set_edge_mode`, the calling process will receive an initial
-message with the state of the pin. This prevents the race condition between
-getting the initial state of the pin and turning on interrupts. Without it,
-you could get the state of the pin, it could change states, and then you could
-start waiting on it for interrupts. If that happened, you would be out of sync.
+Note that after calling `set_edge_mode`, the calling process will receive an
+initial message with the state of the pin. This prevents the race condition
+between getting the initial state of the pin and turning on interrupts. Without
+it, you could get the state of the pin, it could change states, and then you
+could start waiting on it for interrupts. If that happened, you would be out of
+sync.
 
-
-To connect or disconnect an internal pull-up or pull-down resistor to a GPIO pin,
-call the `set_pull_mode` function.
+To connect or disconnect an internal pull-up or pull-down resistor to a GPIO
+pin, call the `set_pull_mode` function.
 
 ```elixir
-iex> ElixirCircuits.GPIO.set_pull_mode(gpio, pull_mode)
+iex> Circuits.GPIO.set_pull_mode(gpio, pull_mode)
 :ok
 ```
 
 Valid `pull_mode` values are `:none` `:pullup`, or `:pulldown`
 
+Note that `set_pull_mode` is platform dependent, and currently only works for
+Raspberry Pi hardware.  Calls to `set_pull_mode` on other platforms will have no
+effect.  The internal pull-up resistor value is between 50K and 65K, and the
+pull-down is between 50K and 60K.  It is not possible to read back the current
+Pull-up/down settings, and GPIO pull-up pull-down resistor connections are
+maintained, even when the CPU is powered down.
 
-Note that `set_pull_mode` is platform dependent, and currently only works for Raspberry Pi hardware.
-Calls to `set_pull_mode` on other platforms will have no effect.
-The internal pull-up resistor value is between 50K and 65K, and the pull-down is between 50K and 60K.
-It is not possible to read back the current Pull-up/down settings, 
-and GPIO pull-up pull-down resistor connections are maintained, even when the CPU is powered down.
-
-
-To get the GPIO pin number for a gpio reference, call the `pin` function. 
+To get the GPIO pin number for a gpio reference, call the `pin` function.
 
 ```elixir
-iex> ElixirCircuits.GPIO.pin(gpio)
+iex> Circuits.GPIO.pin(gpio)
 17
 ```
 
@@ -152,50 +152,38 @@ iex> ElixirCircuits.GPIO.pin(gpio)
 ### Where can I get help?
 
 Most issues people have are on how to communicate with hardware for the first
-time. Since `ElixirCircuits.GPIO` is a thin wrapper on the Linux sys class interface, you
-may find help by searching for similar issues when using Python or C.
+time. Since `Circuits.GPIO` is a thin wrapper on the Linux sys class interface,
+you may find help by searching for similar issues when using Python or C.
 
-For help specifically with `ElixirCircuits.GPIO`, you may also find help on the
-nerves channel on the [elixir-lang Slack](https://elixir-slackin.herokuapp.com/).
-Many [Nerves](http://nerves-project.org) users also use `ElixirCircuits.GPIO`.
+For help specifically with `Circuits.GPIO`, you may also find help on the nerves
+channel on the [elixir-lang Slack](https://elixir-slackin.herokuapp.com/).  Many
+[Nerves](http://nerves-project.org) users also use `Circuits.GPIO`.
 
 ### I tried turning on and off a GPIO as fast as I could. Why was it slow?
 
 Please don't do that - there are so many better ways of accomplishing whatever
 you're trying to do:
 
-  1. If you're trying to drive a servo or dim an LED, look into PWM. Many
-     platforms have PWM hardware and you won't tax your CPU at all. If your
-     platform is missing a PWM, several chips are available that take I2C
-     commands to drive a PWM output.
-  2. If you need to implement a wire level protocol to talk to a device, look
-     for a Linux kernel driver. It may just be a matter of loading the right
-     kernel module.
-  3. If you want a blinking LED to indicate status, `gpio` really should
-     be fast enough to do that, but check out Linux's LED class interface. Linux
-     can flash LEDs, trigger off events and more. See [nerves_leds](https://github.com/nerves-project/nerves_leds).
+1. If you're trying to drive a servo or dim an LED, look into PWM. Many
+   platforms have PWM hardware and you won't tax your CPU at all. If your
+   platform is missing a PWM, several chips are available that take I2C commands to
+   drive a PWM output.
+2. If you need to implement a wire level protocol to talk to a device, look for
+   a Linux kernel driver. It may just be a matter of loading the right kernel
+   module.
+3. If you want a blinking LED to indicate status, `gpio` really should
+   be fast enough to do that, but check out Linux's LED class interface. Linux
+   can flash LEDs, trigger off events and more. See [nerves_leds](https://github.com/nerves-project/nerves_leds).
 
 If you're still intent on optimizing GPIO access, you may be interested in
 [gpio_twiddler](https://github.com/fhunleth/gpio_twiddler).
 
-### Where's PWM support?
-
-On the hardware that I normally use, PWM has been implemented in a
-platform-dependent way. For ease of maintenance, `ElixirCircuits.GPIO` doesn't have any
-platform-dependent code, so supporting it would be difficult. An Elixir PWM
-library would be very interesting, though, should anyone want to implement it.
-
 ### Can I develop code that uses gpio on my laptop?
 
-You'll need to fake out the hardware. Code to do this depends
-on what your hardware actually does, but here's one example:
+You'll need to fake out the hardware. Code to do this depends on what your
+hardware actually does, but here's one example:
 
-  * http://www.cultivatehq.com/posts/compiling-and-testing-elixir-nerves-on-your-host-machine/
+* http://www.cultivatehq.com/posts/compiling-and-testing-elixir-nerves-on-your-host-machine/
 
 Please share other examples if you have them.
-
-### Can I help maintain gpio?
-
-Yes! If your life has been improved by `ElixirCircuits.GPIO` and you want to give back,
-it would be great to have new energy put into this project. Please email me.
 

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -1,5 +1,5 @@
-defmodule ElixirCircuits.GPIO do
-  alias ElixirCircuits.GPIO.Nif
+defmodule Circuits.GPIO do
+  alias Circuits.GPIO.Nif
 
   @type pin_number :: non_neg_integer()
   @type pin_direction :: :input | :output

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -1,11 +1,11 @@
-defmodule ElixirCircuits.GPIO.Nif do
+defmodule Circuits.GPIO.Nif do
   @on_load {:load_nif, 0}
   @compile {:autoload, false}
 
   @moduledoc false
 
   def load_nif() do
-    nif_binary = Application.app_dir(:elixir_circuits_gpio, "priv/gpio_nif")
+    nif_binary = Application.app_dir(:circuits_gpio, "priv/gpio_nif")
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
-defmodule ElixirCircuits.GPIO.MixProject do
+defmodule Circuits.GPIO.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :elixir_circuits_gpio,
+      app: :circuits_gpio,
       version: "0.1.0",
       elixir: "~> 1.6",
       description: description(),
       package: package(),
-      source_url: "https://github.com/elixir-circuits/gpio",
+      source_url: "https://github.com/elixir-circuits/circuits_gpio",
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
@@ -50,7 +50,7 @@ defmodule ElixirCircuits.GPIO.MixProject do
         "Makefile"
       ],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/elixir-circuits/gpio"}
+      links: %{"GitHub" => "https://github.com/elixir-circuits/circuits_gpio"}
     }
   end
 

--- a/src/gpio_nif.c
+++ b/src/gpio_nif.c
@@ -647,4 +647,4 @@ static ErlNifFunc nif_funcs[] = {
     {"pin", 1, pin_gpio, 0}
 };
 
-ERL_NIF_INIT(Elixir.ElixirCircuits.GPIO.Nif, nif_funcs, load, NULL, NULL, unload)
+ERL_NIF_INIT(Elixir.Circuits.GPIO.Nif, nif_funcs, load, NULL, NULL, unload)

--- a/src/gpio_nif.h
+++ b/src/gpio_nif.h
@@ -14,7 +14,7 @@
 
 #ifdef DEBUG
 #define log_location stderr
-//#define LOG_PATH "/tmp/elixir_circuits_gpio.log"
+//#define LOG_PATH "/tmp/circuits_gpio.log"
 #define debug(...) do { enif_fprintf(log_location, __VA_ARGS__); enif_fprintf(log_location, "\r\n"); fflush(log_location); } while(0)
 #define error(...) do { debug(__VA_ARGS__); } while (0)
 #define start_timing() ErlNifTime __start = enif_monotonic_time(ERL_NIF_USEC)


### PR DESCRIPTION
This seems to be the best option for easy to type and not too generic.

I also added back the NIF checking code so that it's possible to build docs on OSX. 